### PR TITLE
Add resource attributes to the LogRecord

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "partial_span_processor"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
     { name = "Mladjan Gadzic", email = "gadzic.mladjan@gmail.com" }
 ]

--- a/tests/partial_span_processor/in_memory_log_exporter.py
+++ b/tests/partial_span_processor/in_memory_log_exporter.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import threading
 import typing
 
-from opentelemetry.sdk._logs import LogData
 from opentelemetry.sdk._logs.export import LogExporter, LogExportResult
+
+if typing.TYPE_CHECKING:
+  from opentelemetry.sdk._logs import LogData
 
 
 class InMemoryLogExporter(LogExporter):
@@ -27,7 +31,7 @@ class InMemoryLogExporter(LogExporter):
   :func:`.get_finished_logs` method.
   """
 
-  def __init__(self):
+  def __init__(self) -> None:
     self._logs = []
     self._lock = threading.Lock()
     self._stopped = False
@@ -36,7 +40,7 @@ class InMemoryLogExporter(LogExporter):
     with self._lock:
       self._logs.clear()
 
-  def get_finished_logs(self) -> typing.Tuple[LogData, ...]:
+  def get_finished_logs(self) -> tuple[LogData, ...]:
     with self._lock:
       return tuple(self._logs)
 


### PR DESCRIPTION
- a new optional parameter `resource` enables setting resource attributes on the partial span log records that are emitted
- type annotations have also been added where missing
- various linter-detected improvements
- version bumped up to 0.0.6