### PR TITLE
Fix JSON serialization when a parent span exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "partial_span_processor"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
     { name = "Mladjan Gadzic", email = "gadzic.mladjan@gmail.com" }
 ]


### PR DESCRIPTION
When a parent span exists, the parent span ID also needs to be serialized as hex (like the trace ID and the span ID).

Version is bumped to 0.0.8.