### PR TITLE
Fix LogRecord deprecated API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
 ]
 license = { text = "Apache-2.0" }
 dependencies = [
-    "opentelemetry-api",
-    "opentelemetry-exporter-otlp",
-    "opentelemetry-exporter-otlp-proto-common",
-    "opentelemetry-exporter-otlp-proto-grpc",
-    "opentelemetry-exporter-otlp-proto-http",
-    "opentelemetry-proto",
-    "opentelemetry-sdk",
-    "opentelemetry-semantic-conventions"
+    "opentelemetry-api>=1.20.0,<1.38",
+    "opentelemetry-exporter-otlp>=1.20.0,<1.38",
+    "opentelemetry-exporter-otlp-proto-common>=1.20.0,<1.38",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<1.38",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0,<1.38",
+    "opentelemetry-proto>=1.20.0,<1.38",
+    "opentelemetry-sdk>=1.20.0,<1.38",
+    "opentelemetry-semantic-conventions>=0.41b0,<0.59b0"
 ]
 
 [project.urls]

--- a/src/partial_span_processor/__init__.py
+++ b/src/partial_span_processor/__init__.py
@@ -27,7 +27,7 @@ from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
 from opentelemetry.proto.trace.v1 import trace_pb2
 from opentelemetry.sdk._logs import LogData, LogRecord
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
-from opentelemetry.trace import TraceFlags
+from opentelemetry.trace import set_span_in_context
 
 from .peekable_queue import PeekableQueue
 
@@ -172,20 +172,18 @@ class PartialSpanProcessor(SpanProcessor):
     traces_dict = json.loads(serialized_traces_data)
     for resource_span in traces_dict.get("resourceSpans", []):
       for scope_span in resource_span.get("scopeSpans", []):
-        for span in scope_span.get("spans", []):
-          span["traceId"] = f"{span_context.trace_id:032x}"
-          span["spanId"] = f"{span_context.span_id:016x}"
+        for span_dict in scope_span.get("spans", []):
+          span_dict["traceId"] = f"{span_context.trace_id:032x}"
+          span_dict["spanId"] = f"{span_context.span_id:016x}"
           if parent:
-            span["parentSpanId"] = f"{parent.span_id:016x}"
+            span_dict["parentSpanId"] = f"{parent.span_id:016x}"
 
     serialized_traces_data = json.dumps(traces_dict, separators=(",", ":"))
 
     log_record = LogRecord(
       timestamp=time.time_ns(),
       observed_timestamp=time.time_ns(),
-      trace_id=span_context.trace_id,
-      span_id=span_context.span_id,
-      trace_flags=TraceFlags().get_default(),
+      context=set_span_in_context(span),
       severity_text="INFO",
       severity_number=SeverityNumber.INFO,
       body=serialized_traces_data,

--- a/tests/partial_span_processor/test_log_record_deprecation.py
+++ b/tests/partial_span_processor/test_log_record_deprecation.py
@@ -1,0 +1,26 @@
+import time
+import unittest
+import warnings
+
+from opentelemetry._logs.severity import SeverityNumber
+from opentelemetry.sdk._logs import LogRecord
+from opentelemetry.trace import TraceFlags
+
+
+class TestLogRecordDeprecation(unittest.TestCase):
+    def test_trace_id_span_id_trace_flags_params_are_deprecated(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            LogRecord(
+                timestamp=time.time_ns(),
+                observed_timestamp=time.time_ns(),
+                trace_id=0x1234567890abcdef1234567890abcdef,
+                span_id=0x1234567890abcdef,
+                trace_flags=TraceFlags().get_default(),
+                severity_text="INFO",
+                severity_number=SeverityNumber.INFO,
+                body="test",
+            )
+        self.assertEqual(len(w), 1)
+        self.assertIn("deprecated", str(w[0].message).lower())
+        self.assertIn("context", str(w[0].message).lower())

--- a/tests/partial_span_processor/test_log_record_deprecation.py
+++ b/tests/partial_span_processor/test_log_record_deprecation.py
@@ -1,26 +1,39 @@
-import time
 import unittest
 import warnings
 
-from opentelemetry._logs.severity import SeverityNumber
-from opentelemetry.sdk._logs import LogRecord
-from opentelemetry.trace import TraceFlags
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.trace import SpanContext, TraceFlags
+
+from src.partial_span_processor import PartialSpanProcessor
+from tests.partial_span_processor.in_memory_log_exporter import InMemoryLogExporter
 
 
 class TestLogRecordDeprecation(unittest.TestCase):
-    def test_trace_id_span_id_trace_flags_params_are_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            LogRecord(
-                timestamp=time.time_ns(),
-                observed_timestamp=time.time_ns(),
+    def setUp(self):
+        self.processor = PartialSpanProcessor(
+            log_exporter=InMemoryLogExporter(),
+            heartbeat_interval_millis=1000,
+            initial_heartbeat_delay_millis=1000,
+            process_interval_millis=1000,
+            resource=Resource(attributes={"service.name": "test"}),
+        )
+
+    def tearDown(self):
+        self.processor.shutdown()
+
+    def test_get_log_data_produces_no_deprecation_warnings(self):
+        tracer = TracerProvider().get_tracer("test")
+        with tracer.start_as_current_span("test_span") as span:
+            span._context = SpanContext(
                 trace_id=0x1234567890abcdef1234567890abcdef,
                 span_id=0x1234567890abcdef,
-                trace_flags=TraceFlags().get_default(),
-                severity_text="INFO",
-                severity_number=SeverityNumber.INFO,
-                body="test",
+                is_remote=False,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
             )
-        self.assertEqual(len(w), 1)
-        self.assertIn("deprecated", str(w[0].message).lower())
-        self.assertIn("context", str(w[0].message).lower())
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                self.processor.get_log_data(span, {"partial.event": "heartbeat"})
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        self.assertEqual(len(deprecation_warnings), 0)


### PR DESCRIPTION
Fixes https://github.com/G-Research/gr-oss/issues/1280

* replaced `trace_id`, `span_id` and `trace_flags` with `Context` inside `LogRecord` constructor
* added test that checks for `LogRecord` deprecation warnings
* pinned otel libs version to comply with internal versions because`opentelemetry-sdk 1.4.0` introduces breaking changes to `LogRecord` which is the reason of CI failure since it always assumes the latest version of deps because those are not pinned in `pyproject.toml`