### PR TITLE
Upgrade OpenTelemetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
 ]
 license = { text = "Apache-2.0" }
 dependencies = [
-    "opentelemetry-api>=1.20.0,<1.38",
-    "opentelemetry-exporter-otlp>=1.20.0,<1.38",
-    "opentelemetry-exporter-otlp-proto-common>=1.20.0,<1.38",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<1.38",
-    "opentelemetry-exporter-otlp-proto-http>=1.20.0,<1.38",
-    "opentelemetry-proto>=1.20.0,<1.38",
-    "opentelemetry-sdk>=1.20.0,<1.38",
-    "opentelemetry-semantic-conventions>=0.41b0,<0.59b0"
+    "opentelemetry-api",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-exporter-otlp-proto-common",
+    "opentelemetry-exporter-otlp-proto-grpc",
+    "opentelemetry-exporter-otlp-proto-http",
+    "opentelemetry-proto",
+    "opentelemetry-sdk",
+    "opentelemetry-semantic-conventions"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
 ]
 license = { text = "Apache-2.0" }
 dependencies = [
-    "opentelemetry-api",
-    "opentelemetry-exporter-otlp",
-    "opentelemetry-exporter-otlp-proto-common",
-    "opentelemetry-exporter-otlp-proto-grpc",
-    "opentelemetry-exporter-otlp-proto-http",
-    "opentelemetry-proto",
-    "opentelemetry-sdk",
-    "opentelemetry-semantic-conventions"
+    "opentelemetry-api>=1.39.0",
+    "opentelemetry-exporter-otlp>=1.39.0",
+    "opentelemetry-exporter-otlp-proto-common>=1.39.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.39.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.39.0",
+    "opentelemetry-proto>=1.39.0",
+    "opentelemetry-sdk>=1.39.0",
+    "opentelemetry-semantic-conventions>=0.60b0"
 ]
 
 [project.urls]

--- a/src/partial_span_processor/__init__.py
+++ b/src/partial_span_processor/__init__.py
@@ -25,7 +25,8 @@ from google.protobuf import json_format
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
 from opentelemetry.proto.trace.v1 import trace_pb2
-from opentelemetry.sdk._logs import LogData, LogRecord
+from opentelemetry._logs import LogRecord
+from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.trace import set_span_in_context
 
@@ -152,7 +153,7 @@ class PartialSpanProcessor(SpanProcessor):
       "partial.body.type": "json/v1",
     }
 
-  def get_log_data(self, span: Span, attributes: dict[str, str]) -> LogData:
+  def get_log_data(self, span: Span, attributes: dict[str, str]) -> ReadableLogRecord:
     instrumentation_scope = span.instrumentation_scope if hasattr(span,
                                                                   "instrumentation_scope") else None
     span_context = span.get_span_context()
@@ -187,11 +188,12 @@ class PartialSpanProcessor(SpanProcessor):
       severity_text="INFO",
       severity_number=SeverityNumber.INFO,
       body=serialized_traces_data,
-      resource=self.resource,
       attributes=attributes,
     )
-    return LogData(
-      log_record=log_record, instrumentation_scope=instrumentation_scope,
+    return ReadableLogRecord(
+      log_record=log_record,
+      resource=self.resource,
+      instrumentation_scope=instrumentation_scope,
     )
 
   def process_delayed_heartbeat_spans(self) -> None:

--- a/tests/partial_span_processor/in_memory_log_exporter.py
+++ b/tests/partial_span_processor/in_memory_log_exporter.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 import threading
 import typing
 
+from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk._logs.export import LogExporter, LogExportResult
-
-if typing.TYPE_CHECKING:
-  from opentelemetry.sdk._logs import LogData
 
 
 class InMemoryLogExporter(LogExporter):
@@ -40,11 +38,11 @@ class InMemoryLogExporter(LogExporter):
     with self._lock:
       self._logs.clear()
 
-  def get_finished_logs(self) -> tuple[LogData, ...]:
+  def get_finished_logs(self) -> tuple[ReadableLogRecord, ...]:
     with self._lock:
       return tuple(self._logs)
 
-  def export(self, batch: typing.Sequence[LogData]) -> LogExportResult:
+  def export(self, batch: typing.Sequence[ReadableLogRecord]) -> LogExportResult:
     if self._stopped:
       return LogExportResult.FAILURE
     with self._lock:

--- a/tests/partial_span_processor/test_partial_span_processor.py
+++ b/tests/partial_span_processor/test_partial_span_processor.py
@@ -151,7 +151,7 @@ class TestPartialSpanProcessor(unittest.TestCase):
     self.assertEqual(logs[0].log_record.attributes["partial.event"], "stop")
     self.assertEqual(logs[0].log_record.attributes["partial.body.type"],
                      "json/v1")
-    self.assertEqual(logs[0].log_record.resource.attributes["service.name"],
+    self.assertEqual(logs[0].resource.attributes["service.name"],
                      "test")
 
   def test_process_delayed_heartbeat_spans(self):


### PR DESCRIPTION
### What
* remove bounds for OTel deps
* refactor code to comply with OTel breaking changes in the latest version

### Why
OTel world introduced breaking changes in the latest version.

### Todo (in separate PR):
* in separate PR bump up version to v0.1.0
* after above PR is merged, create v0.1.0 tag and publish new version